### PR TITLE
separated sync into two difference processes, needs further cleanup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "in.org.klp.konnect"
         minSdkVersion 15
         targetSdkVersion 23
-        versionCode 36
-        versionName "1.1.3"
+        versionCode 37
+        versionName "1.2"
     }
     buildTypes {
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "in.org.klp.konnect"
         minSdkVersion 15
         targetSdkVersion 23
-        versionCode 37
-        versionName "1.2"
+        versionCode 38
+        versionName "1.2.1"
     }
     buildTypes {
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "in.org.klp.konnect"
         minSdkVersion 15
         targetSdkVersion 23
-        versionCode 35
-        versionName "1.1.2"
+        versionCode 36
+        versionName "1.1.3"
     }
     buildTypes {
         release {

--- a/app/src/main/java/in/org/klp/konnect/utils/SyncManager.java
+++ b/app/src/main/java/in/org/klp/konnect/utils/SyncManager.java
@@ -95,6 +95,12 @@ public class SyncManager {
             this.story_url += "&admin2=detect";
         }
 
+        Story last_story = db.fetchByQuery(Story.class,
+                Query.select().where(Story.SYSID.neq(null)).orderBy(Story.SYSID.desc()).limit(1));
+        if (last_story != null) {
+            story_url += "&since_id=" + last_story.getSysid();
+        }
+
         Needle.onBackgroundThread().execute(new UiRelatedTask<Integer>() {
             @Override
             protected Integer doWork() {

--- a/app/src/main/res/layout/activity_reports.xml
+++ b/app/src/main/res/layout/activity_reports.xml
@@ -8,6 +8,8 @@
     android:paddingTop="@dimen/activity_vertical_margin"
     tools:context=".ReportsActivity">
 
+    <!--put sync button on action bar -->
+
     <TableLayout android:id="@+id/boundary_display"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_stories.xml
+++ b/app/src/main/res/layout/activity_stories.xml
@@ -18,7 +18,7 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="UBERAWESOME BOUNDARY"
+            android:text=""
             android:textColor="@color/colorWhite"
             android:textStyle="bold"
             android:textSize="20dp"

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -15,8 +15,9 @@
 
     <TableRow>
         <Button
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="Survey"
             android:id="@+id/survey_button"
             android:textColor="@color/colorWhite"
@@ -30,9 +31,10 @@
             android:paddingBottom="20dp"
             android:textSize="8pt"/>
         <Button
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="Sync"
+            android:layout_weight="1"
+            android:text="Update Surveys"
             android:id="@+id/sync_button"
             android:textColor="@color/colorWhite"
             android:background="@color/colorBrandTurquoise"

--- a/app/src/main/res/menu/sync_at_resource.xml
+++ b/app/src/main/res/menu/sync_at_resource.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_sync_block"
+        android:title="Sync"
+        android:orderInCategory="100"
+        app:showAsAction="always"
+        android:onClick="downloadStoriesForBlock" />
+</menu>


### PR DESCRIPTION
 - Front page sync now only downloads survey, questions and questiongroups
 - each report page has a sync button on top, pressing which downloads all stories for the block that's already been selected